### PR TITLE
8 endpoint

### DIFF
--- a/app/controllers/api/v0/market_vendors_controller.rb
+++ b/app/controllers/api/v0/market_vendors_controller.rb
@@ -2,7 +2,7 @@ class Api::V0::MarketVendorsController < ApplicationController
   def create
     market_vendor = MarketVendor.new(market_vendor_params)
     if market_vendor.save
-        render json: MarketVendorSerializer.new(market_vendor)
+      render json: { message: "Successfully added vendor to market" }, status: :created
     end
   end
 

--- a/app/controllers/api/v0/market_vendors_controller.rb
+++ b/app/controllers/api/v0/market_vendors_controller.rb
@@ -1,0 +1,11 @@
+class Api::V0::MarketVendorsController < ApplicationController
+  def create
+      market_vendor =
+  end
+
+  private
+
+  def market_vendor_params
+    params.permit
+  end
+end

--- a/app/controllers/api/v0/market_vendors_controller.rb
+++ b/app/controllers/api/v0/market_vendors_controller.rb
@@ -3,6 +3,10 @@ class Api::V0::MarketVendorsController < ApplicationController
     market_vendor = MarketVendor.new(market_vendor_params)
     if market_vendor.save
       render json: { message: "Successfully added vendor to market" }, status: :created
+    else
+      message = market_vendor.errors.messages
+      render json: ErrorSerializer.new(ErrorMessage.new(message, 404))
+      .serialize_json, status: :not_found
     end
   end
 

--- a/app/controllers/api/v0/market_vendors_controller.rb
+++ b/app/controllers/api/v0/market_vendors_controller.rb
@@ -1,11 +1,14 @@
 class Api::V0::MarketVendorsController < ApplicationController
   def create
-      market_vendor =
+    market_vendor = MarketVendor.new(market_vendor_params)
+    if market_vendor.save
+        render json: MarketVendorSerializer.new(market_vendor)
+    end
   end
 
   private
 
   def market_vendor_params
-    params.permit
+    params.require(:market_vendor).permit(:vendor_id, :market_id)
   end
 end

--- a/app/controllers/api/v0/market_vendors_controller.rb
+++ b/app/controllers/api/v0/market_vendors_controller.rb
@@ -5,8 +5,7 @@ class Api::V0::MarketVendorsController < ApplicationController
       render json: { message: "Successfully added vendor to market" }, status: :created
     else
       message = market_vendor.errors.messages
-      render json: ErrorSerializer.new(ErrorMessage.new(message, 404))
-      .serialize_json, status: :not_found
+      render json: ErrorSerializer.new(ErrorMessage.new(message, 404)).serializer_validation, status: :not_found
     end
   end
 

--- a/app/controllers/api/v0/markets_controller.rb
+++ b/app/controllers/api/v0/markets_controller.rb
@@ -1,5 +1,1 @@
-class Api::V0::MarketsController < ApplicationController
-    def index
-        render json: MarketSerializer.new(Market.all)
-    end
-end
+git fetch origin

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -7,4 +7,9 @@ class ApplicationController < ActionController::API
     render json: ErrorSerializer.new(ErrorMessage.new(exception.message, 404))
     .serialize_json, status: :not_found
   end
+
+  def bad_request_response(exception)
+    render json: ErrorSerializer.new(ErrorMessage.new(exception.message, 400))
+    .serialize_json, status: :bad_request
+  end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,15 +1,11 @@
 class ApplicationController < ActionController::API
   rescue_from ActiveRecord::RecordNotFound, with: :not_found_response
+  rescue_from ActiveModel::Errors, with: :not_found_response
 
   private
 
   def not_found_response(exception)
     render json: ErrorSerializer.new(ErrorMessage.new(exception.message, 404))
     .serialize_json, status: :not_found
-  end
-
-  def bad_request_response(exception)
-    render json: ErrorSerializer.new(ErrorMessage.new(exception.message, 400))
-    .serialize_json, status: :bad_request
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,5 @@
 class ApplicationController < ActionController::API
   rescue_from ActiveRecord::RecordNotFound, with: :not_found_response
-  rescue_from ActiveModel::Errors, with: :not_found_response
 
   private
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,10 @@
 class ApplicationController < ActionController::API
+  rescue_from ActiveRecord::RecordNotFound, with: :not_found_response
+
+  private
+
+  def not_found_response(exception)
+    render json: ErrorSerializer.new(ErrorMessage.new(exception.message, 404))
+    .serialize_json, status: :not_found
+  end
 end

--- a/app/poros/error_message.rb
+++ b/app/poros/error_message.rb
@@ -1,0 +1,8 @@
+class ErrorMessage
+  attr_reader :message, :status_code
+
+  def initialize(message, status_code)
+    @message = message
+    @status_code = status_code
+  end
+end

--- a/app/poros/error_message.rb
+++ b/app/poros/error_message.rb
@@ -5,4 +5,10 @@ class ErrorMessage
     @message = message
     @status_code = status_code
   end
+
+  def hash_message_to_s
+    @message.map do |object, error|
+    "#{object.to_s.capitalize()} #{error.first.to_s}"
+    end
+  end
 end

--- a/app/serializers/error_serializer.rb
+++ b/app/serializers/error_serializer.rb
@@ -1,0 +1,16 @@
+class ErrorSerializer
+  def initialize(error_object)
+    @error_object = error_object
+  end
+
+  def serialize_json
+    {
+      errors: [
+        {
+          status: @error_object.status_code.to_s,
+          title: @error_object.message
+        }
+      ]
+    }
+  end
+end

--- a/app/serializers/error_serializer.rb
+++ b/app/serializers/error_serializer.rb
@@ -13,4 +13,16 @@ class ErrorSerializer
       ]
     }
   end
+
+  def serializer_validation
+    {
+      errors: [
+        @error_object.each do |object, message|
+          {
+            "detail": "Validation failed: #{object} #{message}"
+          }
+        end
+        ]
+      }
+  end
 end

--- a/app/serializers/error_serializer.rb
+++ b/app/serializers/error_serializer.rb
@@ -17,11 +17,9 @@ class ErrorSerializer
   def serializer_validation
     {
       errors: [
-        @error_object.each do |object, message|
           {
-            "detail": "Validation failed: #{object} #{message}"
+            detail: "Validation failed: #{@error_object.hash_message_to_s.first}"
           }
-        end
         ]
       }
   end

--- a/app/serializers/market_vendor_serializer.rb
+++ b/app/serializers/market_vendor_serializer.rb
@@ -1,0 +1,4 @@
+class MarketVendorSerializer
+  include JSONAPI::Serializer
+  attributes :market_id, :vendor_id
+end

--- a/app/serializers/market_vendor_serializer.rb
+++ b/app/serializers/market_vendor_serializer.rb
@@ -1,4 +1,0 @@
-class MarketVendorSerializer
-  include JSONAPI::Serializer
-  attributes :market_id, :vendor_id
-end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,6 +12,7 @@ Rails.application.routes.draw do
     namespace :v0 do
       resources :markets, only: [:index, :show]
       resources :vendors, only: [:show, :destroy]
+      resources :market_vendors, only: [:create]
     end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,6 +12,7 @@ Rails.application.routes.draw do
     namespace :v0 do
       resources :markets, only: [:index]
       resources :vendors, only: [:show]
+      resources :market_vendors, only: [:create]
     end
   end
 end

--- a/spec/poros/error_message_spec.rb
+++ b/spec/poros/error_message_spec.rb
@@ -1,0 +1,14 @@
+require "rails_helper"
+
+describe "Error Message PORO" do
+  it "exists" do
+    expect(ErrorMessage.new("Error", 404)).to be_an ErrorMessage
+  end
+
+  it "has two attributes" do
+    error_message = ErrorMessage.new("Error", 404)
+
+    expect(error_message.message).to eq("Error")
+    expect(error_message.status_code).to eq(404)
+  end
+end

--- a/spec/poros/error_message_spec.rb
+++ b/spec/poros/error_message_spec.rb
@@ -11,4 +11,18 @@ describe "Error Message PORO" do
     expect(error_message.message).to eq("Error")
     expect(error_message.status_code).to eq(404)
   end
+
+  describe "instance methods" do
+    describe "#hash_message_to_s" do
+      it "turns a Hash message to a String" do
+        hash_message = {
+          :market => ["must exist"]
+        }
+
+      error_message = ErrorMessage.new(hash_message, 404)
+
+      expect(error_message.hash_message_to_s).to eq(["Market must exist"])
+      end
+end
+  end
 end

--- a/spec/requests/api/v0/market_vendor_requests_spec.rb
+++ b/spec/requests/api/v0/market_vendor_requests_spec.rb
@@ -1,0 +1,19 @@
+require "rails_helper"
+
+describe "Market Vendors API" do
+  it "can create one market_vendor" do
+    vendor = create(:vendor)
+    market = create(:market)
+
+    headers = {"CONTENT_TYPE" => "application/json"}
+
+    post "/api/v0/market_vendors", headers: headers, params: JSON.generate(market_id: market.id, vendor_id: vendor.id)
+
+    expect(response).to be_successful
+
+    market_vendor = MarketVendor.last
+
+    expect(market_vendor.vendor_id).to eq(vendor.id)
+    expect(market_vendor.market_id).to eq(market.id)
+  end
+end

--- a/spec/requests/api/v0/market_vendor_requests_spec.rb
+++ b/spec/requests/api/v0/market_vendor_requests_spec.rb
@@ -32,6 +32,24 @@ describe "Market Vendors API" do
 
       post "/api/v0/market_vendors", headers: @headers, params: JSON.generate(body)
       expect(response.status).to eq(404)
+
+      data = JSON.parse(response.body, symbolize_names: true)
+
+      expect(data[:errors]).to be_a(Array)
+      expect(data[:errors].first[:detail]).to eq("Validation failed: Market must exist")
+    end
+
+    xit "has a 422 error" do
+      MarketVendor.create!(market_id: @market.id, vendor_id: @vendor.id)
+      body =    {
+        "market_id": @market.id,
+        "vendor_id": @vendor.id
+      }
+
+      post "/api/v0/market_vendors", headers: @headers, params: JSON.generate(body)
+
+      expect(response.status).to eq(422)
+      expect(response.errors)
     end
   end
 end

--- a/spec/requests/api/v0/market_vendor_requests_spec.rb
+++ b/spec/requests/api/v0/market_vendor_requests_spec.rb
@@ -25,9 +25,13 @@ describe "Market Vendors API" do
 
   describe "sad paths" do
     it "has a 404 error" do
-      post "/api/v0/market_vendors", headers: @headers, params: JSON.generate(market_id: 1, vendor_id: @vendor.id)
+      body =    {
+        "market_id": 1,
+        "vendor_id": @vendor.id
+      }
 
-
+      post "/api/v0/market_vendors", headers: @headers, params: JSON.generate(body)
+      expect(response.status).to eq(404)
     end
   end
 end

--- a/spec/requests/api/v0/market_vendor_requests_spec.rb
+++ b/spec/requests/api/v0/market_vendor_requests_spec.rb
@@ -1,19 +1,33 @@
 require "rails_helper"
 
 describe "Market Vendors API" do
+  before do
+    @headers = {"CONTENT_TYPE" => "application/json"}
+    @vendor = create(:vendor)
+    @market = create(:market)
+  end
+
   it "can create one market_vendor" do
-    vendor = create(:vendor)
-    market = create(:market)
-
-    headers = {"CONTENT_TYPE" => "application/json"}
-
-    post "/api/v0/market_vendors", headers: headers, params: JSON.generate(market_id: market.id, vendor_id: vendor.id)
+    post "/api/v0/market_vendors", headers: @headers, params: JSON.generate(market_id: @market.id, vendor_id: @vendor.id)
 
     expect(response).to be_successful
+    expect(response.status).to eq(201)
+
+    data = JSON.parse(response.body, symbolize_names: true)
+
+    expect(data[:message]).to eq("Successfully added vendor to market")
 
     market_vendor = MarketVendor.last
 
-    expect(market_vendor.vendor_id).to eq(vendor.id)
-    expect(market_vendor.market_id).to eq(market.id)
+    expect(market_vendor.vendor_id).to eq(@vendor.id)
+    expect(market_vendor.market_id).to eq(@market.id)
+  end
+
+  describe "sad paths" do
+    it "has a 404 error" do
+      post "/api/v0/market_vendors", headers: @headers, params: JSON.generate(market_id: 1, vendor_id: @vendor.id)
+
+
+    end
   end
 end

--- a/spec/requests/api/v0/vendors_request_spec.rb
+++ b/spec/requests/api/v0/vendors_request_spec.rb
@@ -27,50 +27,55 @@ describe "Vendors API" do
     expect(vendor_attributes[:credit_accepted]).to eq(true)
   end
 
-  it "can destroy a Vendor" do
-    vendor = create(:vendor)
+  describe "destroy a Vendor" do
+    it "can destroy a Vendor from the database" do
+      vendor = create(:vendor)
 
-    expect(Vendor.count).to eq(1)
+      expect(Vendor.count).to eq(1)
 
-    delete "/api/v0/vendors/#{vendor.id}"
+      delete "/api/v0/vendors/#{vendor.id}"
 
-    expect(response).to be_successful
-    expect(response.code).to eq("204")
-    expect(response).to have_http_status(:no_content)
-    expect(Vendor.count).to eq(0)
-    expect{Vendor.find(vendor.id)}.to raise_error(ActiveRecord::RecordNotFound)
+      expect(response).to be_successful
+      expect(response.code).to eq("204")
+      expect(response).to have_http_status(:no_content)
+      expect(Vendor.count).to eq(0)
+      expect{Vendor.find(vendor.id)}.to raise_error(ActiveRecord::RecordNotFound)
 
-    ### Alternate test to check for destroyed Vendor
+      ### Alternate test to check for destroyed Vendor
 
-    vendor2 = create(:vendor)
+      vendor2 = create(:vendor)
 
-    expect{ delete "/api/v0/vendors/#{vendor2.id}" }.to change(Vendor, :count).by(-1)
-    expect{Vendor.find(vendor2.id)}.to raise_error(ActiveRecord::RecordNotFound)
-  end
+      expect{ delete "/api/v0/vendors/#{vendor2.id}" }.to change(Vendor, :count).by(-1)
+      expect{Vendor.find(vendor2.id)}.to raise_error(ActiveRecord::RecordNotFound)
+    end
 
-  it "can destroy a Vendor along with it's association but not Market" do
-    # Because Vendor has a many to many relationship with a joins table, you can not delete Vendor without also
-    # Deleting MarketVendor, it will raise a foreign key restraint error, therefore associations need to be set up
-    # So that when you destroy Vendor, you also destroy it's associated records
+    it "can destroy a Vendor along with it's association but not Market" do
+      # Because Vendor has a many to many relationship with a joins table, you can not delete Vendor without also
+      # Deleting MarketVendor, it will raise a foreign key restraint error, therefore associations need to be set up
+      # So that when you destroy Vendor, you also destroy it's associated records
 
-    vendor = create(:vendor)
-    market = create(:market)
-    market_vendor = MarketVendor.create!(market_id: market.id, vendor_id: vendor.id)
+      vendor = create(:vendor)
+      market = create(:market)
+      market_vendor = MarketVendor.create!(market_id: market.id, vendor_id: vendor.id)
 
-    expect(Vendor.count).to eq(1)
-    expect(MarketVendor.count).to eq(1)
-    expect(Market.count).to eq(1)
+      expect(Vendor.count).to eq(1)
+      expect(MarketVendor.count).to eq(1)
+      expect(Market.count).to eq(1)
 
-    delete "/api/v0/vendors/#{vendor.id}"
+      delete "/api/v0/vendors/#{vendor.id}"
 
-    expect(response).to be_successful
-    expect(response.code).to eq("204")
-    expect(response).to have_http_status(:no_content)
-    expect(Vendor.count).to eq(0)
-    expect{Vendor.find(vendor.id)}.to raise_error(ActiveRecord::RecordNotFound)
-    expect(MarketVendor.count).to eq(0)
-    expect{MarketVendor.find(market_vendor.id)}.to raise_error(ActiveRecord::RecordNotFound)
-    expect(Market.count).to eq(1)
-    expect(Market.find(market.id)).to eq(market)
-  end
+      expect(response).to be_successful
+      expect(response.code).to eq("204")
+      expect(response).to have_http_status(:no_content)
+      expect(Vendor.count).to eq(0)
+      expect{Vendor.find(vendor.id)}.to raise_error(ActiveRecord::RecordNotFound)
+      expect(MarketVendor.count).to eq(0)
+      expect{MarketVendor.find(market_vendor.id)}.to raise_error(ActiveRecord::RecordNotFound)
+      expect(Market.count).to eq(1)
+      expect(Market.find(market.id)).to eq(market)
+    end
+
+    it "has a 404 error when Vendor id is not valid" do
+      delete "/api/v0/vendors/1"
+    end
 end

--- a/spec/requests/api/v0/vendors_request_spec.rb
+++ b/spec/requests/api/v0/vendors_request_spec.rb
@@ -1,48 +1,49 @@
 require "rails_helper"
 
 describe "Vendors API" do
-  it "can get one Vendor" do
-    #hard coded true to be able to test correct, since be_a(Boolean) is not an option
-    vendor = create(:vendor, credit_accepted: true)
+  describe "Create a Vendor" do
+    it "can get one Vendor" do
+      #hard coded true to be able to test correct, since be_a(Boolean) is not an option
+      vendor = create(:vendor, credit_accepted: true)
 
-    get "/api/v0/vendors/#{vendor.id}"
+      get "/api/v0/vendors/#{vendor.id}"
 
-    expect(response).to be_successful
+      expect(response).to be_successful
 
-    vendor_data = JSON.parse(response.body, symbolize_names: true)
-    expect(vendor_data.keys).to eq([:data])
-    expect(vendor_data[:data].keys).to eq([:id, :type, :attributes])
-    expect(vendor_data[:data][:id]).to be_a(String)
-    expect(vendor_data[:data][:type]).to be_a(String)
-    expect(vendor_data[:data][:attributes]).to be_a(Hash)
+      vendor_data = JSON.parse(response.body, symbolize_names: true)
+      expect(vendor_data.keys).to eq([:data])
+      expect(vendor_data[:data].keys).to eq([:id, :type, :attributes])
+      expect(vendor_data[:data][:id]).to be_a(String)
+      expect(vendor_data[:data][:type]).to be_a(String)
+      expect(vendor_data[:data][:attributes]).to be_a(Hash)
 
-    vendor_attributes = vendor_data[:data][:attributes]
-    attribute_keys = [:name, :description, :contact_name, :contact_phone, :credit_accepted]
+      vendor_attributes = vendor_data[:data][:attributes]
+      attribute_keys = [:name, :description, :contact_name, :contact_phone, :credit_accepted]
 
-    expect(vendor_data[:data][:attributes].keys).to eq(attribute_keys)
-    expect(vendor_attributes[:name]).to be_a(String)
-    expect(vendor_attributes[:description]).to be_a(String)
-    expect(vendor_attributes[:contact_name]).to be_a(String)
-    expect(vendor_attributes[:contact_phone]).to be_a(String)
-    expect(vendor_attributes[:credit_accepted]).to eq(true)
-  end
+      expect(vendor_data[:data][:attributes].keys).to eq(attribute_keys)
+      expect(vendor_attributes[:name]).to be_a(String)
+      expect(vendor_attributes[:description]).to be_a(String)
+      expect(vendor_attributes[:contact_name]).to be_a(String)
+      expect(vendor_attributes[:contact_phone]).to be_a(String)
+      expect(vendor_attributes[:credit_accepted]).to eq(true)
+    end
 
-  describe "sad paths" do
+
     it "will return a 404 error if a Vendor id doesn't exist" do
-    get "/api/v0/vendors/1"
+      get "/api/v0/vendors/1"
 
-    expect(response).to_not be_successful
-    expect(response.status).to eq(404)
+      expect(response).to_not be_successful
+      expect(response.status).to eq(404)
 
-    data = JSON.parse(response.body, symbolize_names: true)
+      data = JSON.parse(response.body, symbolize_names: true)
 
-    expect(data[:errors]).to be_a(Array)
-    expect(data[:errors].first[:status]).to eq("404")
-    expect(data[:errors].first[:title]).to eq("Couldn't find Vendor with 'id'=1")
+      expect(data[:errors]).to be_a(Array)
+      expect(data[:errors].first[:status]).to eq("404")
+      expect(data[:errors].first[:title]).to eq("Couldn't find Vendor with 'id'=1")
     end
   end
 
-  describe "destroy a Vendor" do
+  describe "delete a Vendor" do
     it "can destroy a Vendor from the database" do
       vendor = create(:vendor)
 
@@ -92,5 +93,15 @@ describe "Vendors API" do
 
     it "has a 404 error when Vendor id is not valid" do
       delete "/api/v0/vendors/1"
+
+      expect(response).to_not be_successful
+      expect(response.status).to eq(404)
+
+      data = JSON.parse(response.body, symbolize_names: true)
+
+      expect(data[:errors]).to be_a(Array)
+      expect(data[:errors].first[:status]).to eq("404")
+      expect(data[:errors].first[:title]).to eq("Couldn't find Vendor with 'id'=1")
     end
+  end
 end

--- a/spec/requests/api/v0/vendors_request_spec.rb
+++ b/spec/requests/api/v0/vendors_request_spec.rb
@@ -27,6 +27,21 @@ describe "Vendors API" do
     expect(vendor_attributes[:credit_accepted]).to eq(true)
   end
 
+  describe "sad paths" do
+    it "will return a 404 error if a Vendor id doesn't exist" do
+    get "/api/v0/vendors/1"
+
+    expect(response).to_not be_successful
+    expect(response.status).to eq(404)
+
+    data = JSON.parse(response.body, symbolize_names: true)
+
+    expect(data[:errors]).to be_a(Array)
+    expect(data[:errors].first[:status]).to eq("404")
+    expect(data[:errors].first[:title]).to eq("Couldn't find Vendor with 'id'=1")
+    end
+  end
+
   it "can destroy a Vendor" do
     vendor = create(:vendor)
 


### PR DESCRIPTION
## Type of change
- [x] New feature
- [ ] Bug Fix
- [x] Test
- [x] Refactor/Style

## Description
Relevant User Story(s): 
EP-8, error handling for 404 errors
*Brief summary of the change(s) included in this pull request*

## Implements/Fixes:
- started working on the #serializer_validation that checks if a Model is valid, but it will need to be refactored to somehow encompass #create and #update methods in the future
- ActiveModel::Errors is the class that you get when a new model doesn't save, it can't be used with `rescue from` because it isn't an exception, it's a validation
- Just pushing up so the typical error 404 can be handled across all end points for a sad path
- Added describe blocks for some endpoints so that we can have sad paths distinguished

description closes #

## Check the correct boxes
- [x] This broke nothing
- [ ] This broke some stuff
- [ ] This broke everything

## Testing Changes
- [x] No Tests have been changed
- [ ] Some Tests have been changed
- [ ] All of the Tests have been changed

*Please describe what in the world happened if tests are broken*

## Checklist:
- [ ] My code has no unused/commented out code
- [x] I have reviewed my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have fully tested my code
